### PR TITLE
Add CPU usage graph with vue-chartjs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -218,7 +218,11 @@ var sysinfo = new Vue({
                     responsive: true,
                     maintainAspectRatio: true,
                     scales: {
-                        yAxes: [{ ticks: { max: 100, min: 0 }}]
+                        yAxes: [{ ticks: { max: 100, min: 0 },
+                                  scaleLabel: {
+                                      display: true,
+                                      labelString: 'CPU usage (%)'
+                                  }}]
                     },
                 });
             }

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,9 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <style type="text/css" media="screen">
+body {
+    background-color: #F9F9F9;
+}
 h2 {
     font-size: 1.2em;
     text-align: center;

--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,9 @@ hr.global-cpu-divider {
 div.memory-pie-chart-container {
     padding: 0 40px;
 }
+.progress-bar-ours {
+    background-color: #69D2E7;
+}
 </style>
 </head>
 <body>
@@ -50,7 +53,7 @@ div.memory-pie-chart-container {
                                 <div class="col-xs-2">Global</div>
                                 <div class="col-xs-10">
                                     <div class="progress">
-                                        <div class="progress-bar progress-bar-info" :style="'width: ' + (sysinfo.processor_list[0].cpu_usage * 100) + '%'"></div>
+                                        <div class="progress-bar progress-bar-ours" :style="'width: ' + (sysinfo.processor_list[0].cpu_usage * 100) + '%'"></div>
                                     </div>
                                 </div>
                             </div>
@@ -59,7 +62,7 @@ div.memory-pie-chart-container {
                                 <div class="col-xs-2">{{ processor.name }}</div>
                                 <div class="col-xs-10">
                                     <div class="progress">
-                                        <div class="progress-bar progress-bar-info" :style="'width: ' + (processor.cpu_usage * 100) + '%'"></div>
+                                        <div class="progress-bar progress-bar-ours" :style="'width: ' + (processor.cpu_usage * 100) + '%'"></div>
                                     </div>
                                 </div>
                             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,9 @@
 body {
     background-color: #F9F9F9;
 }
+a {
+    color: #FE4365;
+}
 h2 {
     font-size: 1.2em;
     text-align: center;

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,8 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/simplex/bootstrap.min.css" type="text/css" media="screen"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.2.6/vue.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-chartjs/2.6.2/vue-chartjs.full.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <style type="text/css" media="screen">
 h2 {
     font-size: 1.2em;
@@ -19,34 +21,46 @@ div.sort {
 hr.global-cpu-divider {
     margin-top: 0;
 }
+.nav-tabs {
+    margin-bottom: 15px;
+}
 </style>
 </head>
 <body>
 <div id="sysinfo" class="container" v-if="sysinfo">
     <h2>{{ sysinfo.hostname }} &mdash; {{ sysinfo.uptime }}</h2>
     <hr/>
-    <line-chart :chart-data="processorUsageHistory.chartData"></line-chart>
-    <hr/>
     <div class="row">
         <div class="col-md-6">
             <div class="panel panel-default">
                 <div class="panel-heading">CPU Usage</div>
                 <div class="panel-body">
-                    <div class="row">
-                        <div class="col-xs-2">Global</div>
-                        <div class="col-xs-10">
-                            <div class="progress">
-                                <div class="progress-bar progress-bar-info" :style="'width: ' + (sysinfo.processor_list[0].cpu_usage * 100) + '%'"></div>
+                    <ul class="nav nav-tabs">
+                        <li class="active"><a href="#cpu_usage_bars" data-toggle="tab">Current</a></li>
+                        <li><a href="#cpu_usage_graph" data-toggle="tab">History</a></li>
+                    </ul>
+                    <div class="tab-content">
+                        <div class="tab-pane fade active in" id="cpu_usage_bars">
+                            <div class="row">
+                                <div class="col-xs-2">Global</div>
+                                <div class="col-xs-10">
+                                    <div class="progress">
+                                        <div class="progress-bar progress-bar-info" :style="'width: ' + (sysinfo.processor_list[0].cpu_usage * 100) + '%'"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <hr class="global-cpu-divider">
+                            <div class="row" v-for="processor in sysinfo.processor_list.slice(1)">
+                                <div class="col-xs-2">{{ processor.name }}</div>
+                                <div class="col-xs-10">
+                                    <div class="progress">
+                                        <div class="progress-bar progress-bar-info" :style="'width: ' + (processor.cpu_usage * 100) + '%'"></div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <hr class="global-cpu-divider">
-                    <div class="row" v-for="processor in sysinfo.processor_list.slice(1)">
-                        <div class="col-xs-2">{{ processor.name }}</div>
-                        <div class="col-xs-10">
-                            <div class="progress">
-                                <div class="progress-bar progress-bar-info" :style="'width: ' + (processor.cpu_usage * 100) + '%'"></div>
-                            </div>
+                        <div class="tab-pane fade" id="cpu_usage_graph">
+                            <line-chart :chart-data="processorUsageHistory.chartData"></line-chart>
                         </div>
                     </div>
                 </div>
@@ -182,7 +196,7 @@ var sysinfo = new Vue({
                 this.renderChart(this.chartData, {
                     animation: false,
                     responsive: true,
-                    maintainAspectRatio: false,
+                    maintainAspectRatio: true,
                     scales: {
                         yAxes: [{ ticks: { max: 100, min: 0 }}]
                     },

--- a/src/index.html
+++ b/src/index.html
@@ -24,6 +24,9 @@ hr.global-cpu-divider {
 .nav-tabs {
     margin-bottom: 15px;
 }
+div.memory-pie-chart-container {
+    padding: 0 40px;
+}
 </style>
 </head>
 <body>
@@ -95,11 +98,13 @@ hr.global-cpu-divider {
             <div class="panel panel-default">
                 <div class="panel-body">
                     <div class="row">
-                        <div class="col-xs-6">
-                            <pie-chart :chart-data="memoryUsageChartData" :options="{ title: { display: true, text: 'Memory' }}"></pie-chart>
+                        <div class="col-xs-6 memory-pie-chart-container">
+                            <pie-chart :chart-data="memoryUsageChartData" :options="{ title: { display: true, text: 'Memory' },
+                                                                                      legend: { display: false } }"></pie-chart>
                         </div>
-                        <div class="col-xs-6">
-                            <pie-chart :chart-data="swapUsageChartData" :options="{ title: { display: true, text: 'Swap' }}"></pie-chart>
+                        <div class="col-xs-6 memory-pie-chart-container">
+                            <pie-chart :chart-data="swapUsageChartData" :options="{ title: { display: true, text: 'Swap' },
+                                                                                    legend: { display: false } }"></pie-chart>
                         </div>
                     </div>
                     <table class="table table-striped table-hover">

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
 <title>sysinfo-web</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/simplex/bootstrap.min.css" type="text/css" media="screen"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.2.6/vue.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-chartjs/2.6.2/vue-chartjs.full.min.js"></script>
 <style type="text/css" media="screen">
 h2 {
     font-size: 1.2em;
@@ -23,6 +24,8 @@ hr.global-cpu-divider {
 <body>
 <div id="sysinfo" class="container" v-if="sysinfo">
     <h2>{{ sysinfo.hostname }} &mdash; {{ sysinfo.uptime }}</h2>
+    <hr/>
+    <line-chart :chart-data="processorUsageHistory.chartData"></line-chart>
     <hr/>
     <div class="row">
         <div class="col-md-6">
@@ -171,9 +174,29 @@ hr.global-cpu-divider {
 
 var sysinfo = new Vue({
     el: '#sysinfo',
+    components: {
+        "line-chart": {
+            extends: VueChartJs.Line,
+            mixins: [VueChartJs.mixins.reactiveProp],
+            mounted: function() {
+                this.renderChart(this.chartData, {
+                    animation: false,
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        yAxes: [{ ticks: { max: 100, min: 0 }}]
+                    },
+                });
+            }
+        },
+    },
     data: {
         columns: {"PID": "pid", "Name": "name", "UID": "uid", "GID": "gid", "CPU": "cpu_usage", "Memory": "memory"},
         sortKey: "cpu_usage",
+        processorUsageHistory: {
+            chartData: null,
+            history: [],
+        },
         reverse: true,
         sysinfo: null,
     },
@@ -195,8 +218,62 @@ var sysinfo = new Vue({
                     values.push(self.sysinfo.process_list[proc]);
                 }
                 self.sysinfo.process_list = values;
+                self.addProcessorUsageHistory(self.sysinfo.processor_list.slice(1));
             }
             xhr.send();
+        },
+        addProcessorUsageHistory: function(data) {
+            var self = this;
+            var processor_list = [];
+            for (processor in data) {
+                processor_list.push({
+                    name: data[processor].name,
+                    usage: Math.floor(data[processor].cpu_usage * 100),
+                    time: new Date(),
+                });
+            }
+            self.processorUsageHistory.history.push(processor_list);
+            if (self.processorUsageHistory.history.length > 300 / 5) {
+                self.processorUsageHistory.history.shift();
+            }
+            self.updateProcessorUsageHistoryChartData();
+        },
+        updateProcessorUsageHistoryChartData: function() {
+            var self = this;
+            var labels = [];
+            var datasets = [];
+            var colors = [
+              'rgb(217, 35, 15)', 'rgb(192, 152, 83)', 'rgb(185, 74, 72)', 'rgb(70, 136, 71)', 'rgb(58, 135, 173)'
+            ];
+
+            for (processor_index in self.processorUsageHistory.history[0]) {
+                var history = [];
+                for (i in self.processorUsageHistory.history) {
+                    history.push(self.processorUsageHistory.history[i][processor_index].usage);
+                }
+                datasets.push({
+                    label: self.processorUsageHistory.history[0][processor_index].name,
+                    data: history,
+                    borderColor: colors[processor_index % 5],
+                });
+            }
+
+            for (var i = 0; i <= 300; i = i + 5) {
+                var future = new Date(self.processorUsageHistory.history[0][0].time);
+                future.setSeconds(future.getSeconds() + i);
+                if (i % 60 == 0) {
+                    labels.push(('0' + future.getHours()).slice(-2) + ':' +
+                                ('0' + future.getMinutes()).slice(-2) + ':' +
+                                ('0' + future.getSeconds()).slice(-2));
+                } else  {
+                    labels.push('');
+                }
+            }
+
+            self.processorUsageHistory.chartData = {
+                labels: labels,
+                datasets: datasets,
+            };
         },
         sortBy: function(sortKey) {
             this.reverse = (this.sortKey == this.columns[sortKey]) ? ! this.reverse : true;

--- a/src/index.html
+++ b/src/index.html
@@ -199,12 +199,14 @@ var sysinfo = new Vue({
         },
         reverse: true,
         sysinfo: null,
+        update_interval: 5000, // milliseconds
+        chart_length: 300,     // seconds
     },
     created: function() {
         this.fetchData();
         setInterval(function() {
             this.fetchData();
-        }.bind(this), 5000); 
+        }.bind(this), this.update_interval); 
     },
     methods: {
         fetchData: function() {
@@ -233,7 +235,7 @@ var sysinfo = new Vue({
                 });
             }
             self.processorUsageHistory.history.push(processor_list);
-            if (self.processorUsageHistory.history.length > 300 / 5) {
+            if (self.processorUsageHistory.history.length > self.chart_length / (self.update_interval / 1000)) {
                 self.processorUsageHistory.history.shift();
             }
             self.updateProcessorUsageHistoryChartData();
@@ -258,7 +260,7 @@ var sysinfo = new Vue({
                 });
             }
 
-            for (var i = 0; i <= 300; i = i + 5) {
+            for (var i = 0; i <= self.chart_length; i = i + 5) {
                 var future = new Date(self.processorUsageHistory.history[0][0].time);
                 future.setSeconds(future.getSeconds() + i);
                 if (i % 60 == 0) {

--- a/src/index.html
+++ b/src/index.html
@@ -215,6 +215,11 @@ var sysinfo = new Vue({
         sysinfo: null,
         update_interval: 5000, // milliseconds
         chart_length: 300,     // seconds
+        chart_colors: [
+            '#69D2E7', '#FE4365', '#ECD078', '#53777A', '#FC9D9A', '#D95B43',
+            '#E0E4CC', '#F9CDAD', '#C02942', '#F38630', '#C8C8A9', '#542437',
+            '#FA6900', '#83AF9B', '#A7DBD8',
+        ],
     },
     created: function() {
         this.fetchData();
@@ -258,9 +263,6 @@ var sysinfo = new Vue({
             var self = this;
             var labels = [];
             var datasets = [];
-            var colors = [
-              'rgb(217, 35, 15)', 'rgb(192, 152, 83)', 'rgb(185, 74, 72)', 'rgb(70, 136, 71)', 'rgb(58, 135, 173)'
-            ];
 
             for (processor_index in self.processorUsageHistory.history[0]) {
                 var history = [];
@@ -270,7 +272,8 @@ var sysinfo = new Vue({
                 datasets.push({
                     label: self.processorUsageHistory.history[0][processor_index].name,
                     data: history,
-                    borderColor: colors[processor_index % 5],
+                    borderColor: self.chart_colors[processor_index % self.chart_colors.length],
+                    backgroundColor: 'rgba(255, 255, 255, 0)'
                 });
             }
 

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,13 @@ hr.global-cpu-divider {
     margin-top: 0;
 }
 .nav-tabs {
-    margin-bottom: 15px;
+    border-bottom: none;
+}
+.nav-tabs li.active a {
+    background-color: #fff;
+}
+.cpu-usage-panel {
+    border-top-left-radius: 0;
 }
 div.memory-pie-chart-container {
     padding: 0 40px;
@@ -41,12 +47,12 @@ div.memory-pie-chart-container {
     <hr/>
     <div class="row">
         <div class="col-md-6">
-            <div class="panel panel-default">
+            <ul class="nav nav-tabs">
+                <li class="active"><a href="#cpu_usage_bars" data-toggle="tab">CPU Usage</a></li>
+                <li><a href="#cpu_usage_graph" data-toggle="tab">History</a></li>
+            </ul>
+            <div class="panel panel-default cpu-usage-panel">
                 <div class="panel-body">
-                    <ul class="nav nav-tabs">
-                        <li class="active"><a href="#cpu_usage_bars" data-toggle="tab">Current</a></li>
-                        <li><a href="#cpu_usage_graph" data-toggle="tab">History</a></li>
-                    </ul>
                     <div class="tab-content">
                         <div class="tab-pane fade active in" id="cpu_usage_bars">
                             <div class="row">

--- a/src/index.html
+++ b/src/index.html
@@ -102,12 +102,12 @@ div.memory-pie-chart-container {
                 <div class="panel-body">
                     <div class="row">
                         <div class="col-xs-6 memory-pie-chart-container">
-                            <pie-chart :chart-data="memoryUsageChartData" :options="{ title: { display: true, text: 'Memory' },
-                                                                                      legend: { display: false } }"></pie-chart>
+                            <doughnut-chart :chart-data="memoryUsageChartData" :options="{ title: { display: true, text: 'Memory' },
+                                                                                      legend: { display: false } }"></doughnut-chart>
                         </div>
                         <div class="col-xs-6 memory-pie-chart-container">
-                            <pie-chart :chart-data="swapUsageChartData" :options="{ title: { display: true, text: 'Swap' },
-                                                                                    legend: { display: false } }"></pie-chart>
+                            <doughnut-chart :chart-data="swapUsageChartData" :options="{ title: { display: true, text: 'Swap' },
+                                                                                    legend: { display: false } }"></doughnut-chart>
                         </div>
                     </div>
                     <table class="table table-striped table-hover">
@@ -211,8 +211,8 @@ var sysinfo = new Vue({
                 });
             }
         },
-        "pie-chart": {
-            extends: VueChartJs.Pie,
+        "doughnut-chart": {
+            extends: VueChartJs.Doughnut,
             mixins: [VueChartJs.mixins.reactiveProp],
             props: ['options'],
             mounted: function() {

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,6 @@ hr.global-cpu-divider {
     <div class="row">
         <div class="col-md-6">
             <div class="panel panel-default">
-                <div class="panel-heading">CPU Usage</div>
                 <div class="panel-body">
                     <ul class="nav nav-tabs">
                         <li class="active"><a href="#cpu_usage_bars" data-toggle="tab">Current</a></li>
@@ -66,7 +65,6 @@ hr.global-cpu-divider {
                 </div>
             </div>
             <div class="panel panel-default">
-                <div class="panel-heading">Disks</div>
                 <div class="panel-body">
                     <table class="table table-striped table-hover">
                         <thead>
@@ -95,7 +93,6 @@ hr.global-cpu-divider {
         </div>
         <div class="col-md-6">
             <div class="panel panel-default">
-                <div class="panel-heading">Memory Usage</div>
                 <div class="panel-body">
                     <div class="row">
                         <div class="col-xs-6">
@@ -132,7 +129,6 @@ hr.global-cpu-divider {
                 </div>
             </div>
             <div class="panel panel-default">
-                <div class="panel-heading">Components</div>
                 <div class="panel-body">
                     <table class="table table-striped table-hover">
                         <thead>
@@ -160,7 +156,6 @@ hr.global-cpu-divider {
     <div class="row">
         <div class="col-xs-12">
             <div class="panel panel-default">
-                <div class="panel-heading">Processes</div>
                 <div class="panel-body">
                     <table class="table table-striped table-hover">
                         <thead>

--- a/src/index.html
+++ b/src/index.html
@@ -97,8 +97,13 @@ hr.global-cpu-divider {
             <div class="panel panel-default">
                 <div class="panel-heading">Memory Usage</div>
                 <div class="panel-body">
-                    <div class="progress">
-                        <div class="progress-bar progress-bar-info" :style="'width: ' + (sysinfo.memory[1] * 100 / sysinfo.memory[0]) + '%'"></div>
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <pie-chart :chart-data="memoryUsageChartData" :options="{ title: { display: true, text: 'Memory' }}"></pie-chart>
+                        </div>
+                        <div class="col-xs-6">
+                            <pie-chart :chart-data="swapUsageChartData" :options="{ title: { display: true, text: 'Swap' }}"></pie-chart>
+                        </div>
                     </div>
                     <table class="table table-striped table-hover">
                         <thead>
@@ -203,6 +208,20 @@ var sysinfo = new Vue({
                 });
             }
         },
+        "pie-chart": {
+            extends: VueChartJs.Pie,
+            mixins: [VueChartJs.mixins.reactiveProp],
+            props: ['options'],
+            mounted: function() {
+                var options = {
+                    animation: false,
+                    responsive: true,
+                    maintainAspectRatio: true,
+                };
+                Object.assign(options, this.options);
+                this.renderChart(this.chartData, options);
+            }
+        },
     },
     data: {
         columns: {"PID": "pid", "Name": "name", "UID": "uid", "GID": "gid", "CPU": "cpu_usage", "Memory": "memory"},
@@ -211,6 +230,8 @@ var sysinfo = new Vue({
             chartData: null,
             history: [],
         },
+        memoryUsageChartData: null,
+        swapUsageChartData: null,
         reverse: true,
         sysinfo: null,
         update_interval: 5000, // milliseconds
@@ -240,6 +261,7 @@ var sysinfo = new Vue({
                 }
                 self.sysinfo.process_list = values;
                 self.addProcessorUsageHistory(self.sysinfo.processor_list.slice(1));
+                self.updateMemoryUsageChartData(self.sysinfo.memory);
             }
             xhr.send();
         },
@@ -261,7 +283,6 @@ var sysinfo = new Vue({
         },
         updateProcessorUsageHistoryChartData: function() {
             var self = this;
-            var labels = [];
             var datasets = [];
 
             for (processor_index in self.processorUsageHistory.history[0]) {
@@ -277,6 +298,14 @@ var sysinfo = new Vue({
                 });
             }
 
+            self.processorUsageHistory.chartData = {
+                labels: self.generateLabels(),
+                datasets: datasets,
+            };
+        },
+        generateLabels: function() {
+            var self = this;
+            var labels = [];
             for (var i = 0; i <= self.chart_length; i = i + 5) {
                 var future = new Date(self.processorUsageHistory.history[0][0].time);
                 future.setSeconds(future.getSeconds() + i);
@@ -288,10 +317,39 @@ var sysinfo = new Vue({
                     labels.push('');
                 }
             }
-
-            self.processorUsageHistory.chartData = {
-                labels: labels,
-                datasets: datasets,
+            return labels;
+        },
+        updateMemoryUsageChartData: function(memory) {
+            var self = this;
+            self.memoryUsageChartData = {
+                labels: [
+                    "Used",
+                    "Free"
+                ],
+                datasets: [
+                    {
+                        data: [ memory[1], memory[2] ],
+                        backgroundColor: [
+                            self.chart_colors[1],
+                            self.chart_colors[0],
+                        ],
+                    }
+                ]
+            };
+            self.swapUsageChartData = {
+                labels: [
+                    "Used",
+                    "Free"
+                ],
+                datasets: [
+                    {
+                        data: [ memory[4], memory[5] ],
+                        backgroundColor: [
+                            self.chart_colors[1],
+                            self.chart_colors[0],
+                        ],
+                    }
+                ]
             };
         },
         sortBy: function(sortKey) {


### PR DESCRIPTION
@GuillaumeGomez what do you think? This is similar to your implementation, it's only using vue-chartjs. We can also move `<line-chart>` to anywhere we want (hopefully into a tab :smile:) and re-use it for something else.

I used bootstrap colors (there is only 5 colors in this theme, maybe we can expand). Also disabled dancing-lines animation.

**TODO:**

* [x] Time labels needs padding.
* [x] Move CPU usage chart into a tab panel inside CPU Usage panel.

Closes: #9 